### PR TITLE
add matplotlib to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ pymcubes
 setuptools==59.5.0
 icecream
 torch_efficient_distloss
+matplotlib


### PR DESCRIPTION
After installing the project using `requirements.txt` following the instructions in the README, I encountered the following error while training a model:

```
ModuleNotFoundError: No module named 'matplotlib'
```

Obviously, this is caused by the absence of `matplotlib` from the `requirements.txt`.
I've added it to the file now, so others will not have the same issue.