### PR TITLE
Make paths OS-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ bash single_runner_womask.sh configs/dtu_e2e_womask exp 122
 bash single_runner_womask.sh configs/mobilebrick_e2e_womask/ exp <scene>
 ```
 
+> **Note**
+> For Windows users, please use the provided batch scripts with extension`.bat` instead of the bash scripts with extension `.sh`
+> Additionally, the forward slashes `/` in the paths should be replaced with backslashes `\`.
+> A batch script can be run simply through `<script_name>.bat <arg1> ... <argN>`.
 
 ### NVS evaluation
 ```

--- a/configs/blendedmvs_e2e/coarse.py
+++ b/configs/blendedmvs_e2e/coarse.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/blended_mvs'
+basedir = os.path.join('.', 'logs', 'blended_mvs')
 train_all = True
 reso_level = 2
 exp_stage = 'coarse'
 
 
 data = dict(
-    datadir='./data/BlendedMVS/',
+    datadir=os.path.join('.', 'data', 'BlendedMVS'),
     dataset_type='blendedmvs',
     inverse_y=True,
     white_bkgd=True, # need to manually adjust the background color for BlendedMVS

--- a/configs/blendedmvs_e2e/fine.py
+++ b/configs/blendedmvs_e2e/fine.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/blended_mvs'
+basedir = os.path.join('.', 'logs', 'blended_mvs')
 train_all = False
 reso_level = 1
 exp_stage = 'fine'
 
 
 data = dict(
-    datadir='./data/BlendedMVS/',
+    datadir=os.path.join('.', 'data', 'BlendedMVS'),
     dataset_type='blendedmvs',
     inverse_y=True,
     white_bkgd=True, # need to manually adjust the background color for BlendedMVS

--- a/configs/custom_e2e/coarse.py
+++ b/configs/custom_e2e/coarse.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/custom'
+basedir = os.path.join('.', 'logs', 'custom')
 train_all = True
 reso_level = 2
 exp_stage = 'coarse'
 
 
 data = dict(
-    datadir='./data/',
+    datadir=os.path.join('.', 'data'),
     dataset_type='dtu',
     inverse_y=True,
     white_bkgd= False

--- a/configs/custom_e2e/fine.py
+++ b/configs/custom_e2e/fine.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/custom'
+basedir = os.path.join('.', 'logs', 'custom')
 train_all = False
 reso_level = 1
 exp_stage = 'fine'
 
 
 data = dict(
-    datadir='./data/',
+    datadir=os.path.join('.', 'data'),
     dataset_type='dtu',
     inverse_y=True,
     white_bkgd=False,

--- a/configs/deepvoxels_e2e/coarse.py
+++ b/configs/deepvoxels_e2e/coarse.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/deepvoxels'
+basedir = os.path.join('.', 'logs', 'deepvoxels')
 train_all = True
 reso_level = 2
 exp_stage = 'coarse'
 
 
 data = dict(
-    datadir='./data/deepvoxels/',
+    datadir=os.path.join('.', 'data', 'deepvoxels'),
     dataset_type='deepvoxels',
     # inverse_y=True,
     white_bkgd=True,

--- a/configs/deepvoxels_e2e/fine.py
+++ b/configs/deepvoxels_e2e/fine.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/deepvoxels'
+basedir = os.path.join('.', 'logs', 'deepvoxels')
 train_all = False
 reso_level = 1
 exp_stage = 'fine'
 
 
 data = dict(
-    datadir='./data/deepvoxels/',
+    datadir=os.path.join('.', 'data', 'deepvoxels'),
     dataset_type='deepvoxels',
     # inverse_y=True,
     white_bkgd=True,

--- a/configs/default.py
+++ b/configs/default.py
@@ -1,7 +1,8 @@
+import os
 from copy import deepcopy
 
-expname = None                    # experiment name
-basedir = './logs/'               # where to store ckpts and logs
+expname = None                       # experiment name
+basedir = os.path.join('.', 'logs')  # where to store ckpts and logs
 
 ''' Template of data options
 '''

--- a/configs/default_fine_s.py
+++ b/configs/default_fine_s.py
@@ -1,7 +1,8 @@
+import os
 from copy import deepcopy
 
-expname = None                    # experiment name
-basedir = './logs/'               # where to store ckpts and logs
+expname = None                       # experiment name
+basedir = os.path.join('.', 'logs')  # where to store ckpts and logs
 
 ''' Template of data options
 '''

--- a/configs/dtu_e2e/coarse.py
+++ b/configs/dtu_e2e/coarse.py
@@ -1,7 +1,9 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/dtu'
+basedir = os.path.join('.', 'logs', 'dtu')
 train_all = True
 reso_level = 2
 exp_stage = 'coarse'
@@ -12,7 +14,7 @@ white_list = [24, 40, 110]
 black_list = [37, 55, 63, 65, 69, 83, 97, 105, 106, 114, 118, 122]
 
 data = dict(
-    datadir='./data/DTU/dtu_scan',
+    datadir=os.path.join('.', 'data', 'DTU', 'dtu_scan'),
     dataset_type='dtu',
     inverse_y=True,
     white_bkgd= False

--- a/configs/dtu_e2e/fine.py
+++ b/configs/dtu_e2e/fine.py
@@ -1,7 +1,9 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/dtu'
+basedir = os.path.join('.', 'logs', 'dtu')
 train_all = False
 reso_level = 1
 exp_stage = 'fine'
@@ -11,7 +13,7 @@ white_list = [24, 40, 110]
 black_list = [37, 55, 63, 65, 69, 83, 97, 105, 106, 114, 118, 122]
 
 data = dict(
-    datadir='./data/DTU/dtu_scan',
+    datadir=os.path.join('.', 'data', 'DTU', 'dtu_scan'),
     dataset_type='dtu',
     inverse_y=True,
     white_bkgd=False,

--- a/configs/dtu_e2e_womask/coarse.py
+++ b/configs/dtu_e2e_womask/coarse.py
@@ -1,7 +1,9 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/dtu'
+basedir = os.path.join('.', 'logs', 'dtu')
 train_all = True
 reso_level = 2
 exp_stage = 'coarse'
@@ -11,7 +13,7 @@ white_list = [24, 40, 110]
 black_list = [37, 55, 63, 65, 69, 83, 97, 105, 106, 114, 118, 122]
 
 data = dict(
-    datadir='./data/DTU/dtu_scan',
+    datadir=os.path.join('.', 'data', 'DTU', 'dtu_scan'),
     dataset_type='dtu',
     inverse_y=True,
     white_bkgd= False,

--- a/configs/dtu_e2e_womask/fine.py
+++ b/configs/dtu_e2e_womask/fine.py
@@ -1,7 +1,9 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/dtu'
+basedir = os.path.join('.', 'logs', 'dtu')
 train_all = False
 reso_level = 1
 exp_stage = 'fine'
@@ -11,7 +13,7 @@ white_list = [24, 40, 110]
 black_list = [37, 55, 63, 65, 69, 83, 97, 105, 106, 114, 118, 122]
 
 data = dict(
-    datadir='./data/DTU/dtu_scan',
+    datadir=os.path.join('.', 'data', 'DTU', 'dtu_scan'),
     dataset_type='dtu',
     inverse_y=True,
     white_bkgd=False,

--- a/configs/mobilebrick_e2e_womask/coarse.py
+++ b/configs/mobilebrick_e2e_womask/coarse.py
@@ -1,7 +1,9 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = ''
-basedir = './logs/mobile_brick'
+basedir = os.path.join('.', 'logs', 'mobile_brick')
 train_all = True
 reso_level = 2
 exp_stage = 'coarse'
@@ -9,7 +11,7 @@ exp_stage = 'coarse'
 use_sp_color = False
 
 data = dict(
-    datadir='./data/mobile_brick/test/',
+    datadir=os.path.join('.', 'data', 'mobile_brick', 'test'),
     dataset_type='mobile_brick',
     inverse_y=True,
     white_bkgd= False,

--- a/configs/mobilebrick_e2e_womask/fine.py
+++ b/configs/mobilebrick_e2e_womask/fine.py
@@ -1,7 +1,9 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = ''
-basedir = './logs/mobile_brick'
+basedir = os.path.join('.', 'logs', 'mobile_brick')
 train_all = False
 reso_level = 1
 exp_stage = 'fine'
@@ -9,7 +11,7 @@ exp_stage = 'fine'
 use_sp_color = False
 
 data = dict(
-    datadir='./data/mobile_brick/test/',
+    datadir=os.path.join('.', 'data', 'mobile_brick', 'test'),
     dataset_type='mobile_brick',
     inverse_y=True,
     white_bkgd= False,

--- a/configs/nerf_synthetic_e2e/coarse.py
+++ b/configs/nerf_synthetic_e2e/coarse.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/nerf_synthetic'
+basedir = os.path.join('.', 'logs', 'nerf_synthetic')
 train_all = True
 reso_level = 2
 exp_stage = 'coarse'
 
 
 data = dict(
-    datadir='./data/nerf_synthetic/',
+    datadir=os.path.join('.', 'data', 'nerf_synthetic'),
     dataset_type='blender',
     # inverse_y=True,
     white_bkgd=True,

--- a/configs/nerf_synthetic_e2e/fine.py
+++ b/configs/nerf_synthetic_e2e/fine.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/nerf_synthetic'
+basedir = os.path.join('.', 'logs', 'nerf_synthetic')
 train_all = False
 reso_level = 1
 exp_stage = 'fine'
 
 
 data = dict(
-    datadir='./data/nerf_synthetic/',
+    datadir=os.path.join('.', 'data', 'nerf_synthetic'),
     dataset_type='blender',
     # inverse_y=True,
     white_bkgd=True,

--- a/configs/nvsf_e2e/coarse.py
+++ b/configs/nvsf_e2e/coarse.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/nsvf'
+basedir = os.path.join('.', 'logs', 'nsvf')
 train_all = True
 reso_level = 2
 exp_stage = 'coarse'
 
 
 data = dict(
-    datadir='./data/Synthetic_NSVF/',
+    datadir=os.path.join('.', 'data', 'Synthetic_NSVF'),
     dataset_type='nsvf',
     inverse_y=True,
     white_bkgd=True,

--- a/configs/nvsf_e2e/fine.py
+++ b/configs/nvsf_e2e/fine.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/nsvf'
+basedir = os.path.join('.', 'logs', 'nsvf')
 train_all = False
 reso_level = 1
 exp_stage = 'fine'
 
 
 data = dict(
-    datadir='./data/Synthetic_NSVF/',
+    datadir=os.path.join('.', 'data', 'Synthetic_NSVF'),
     dataset_type='nsvf',
     inverse_y=True,
     white_bkgd=True,

--- a/configs/tanks_and_temple_e2e/coarse.py
+++ b/configs/tanks_and_temple_e2e/coarse.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/tanks_and_temple'
+basedir = os.path.join('.', 'logs', 'tanks_and_temple')
 train_all = True
 reso_level = 2
 exp_stage = 'coarse'
 
 
 data = dict(
-    datadir='./data/TanksAndTemple/',
+    datadir=os.path.join('.', 'data', 'TanksAndTemple'),
     dataset_type='tankstemple',
     inverse_y=True,
     load2gpu_on_the_fly=True,

--- a/configs/tanks_and_temple_e2e/fine.py
+++ b/configs/tanks_and_temple_e2e/fine.py
@@ -1,14 +1,16 @@
-_base_ = '../default_fine_s.py'
+import os
+
+_base_ = os.path.join('..', 'default_fine_s.py')
 
 expname = 'scan'
-basedir = './logs/tanks_and_temple'
+basedir = os.path.join('.', 'logs', 'tanks_and_temple')
 train_all = False
 reso_level = 1
 exp_stage = 'fine'
 
 
 data = dict(
-    datadir='./data/TanksAndTemple/',
+    datadir=os.path.join('.', 'data', 'TanksAndTemple'),
     dataset_type='tankstemple',
     inverse_y=True,
     load2gpu_on_the_fly=True,

--- a/lib/dtu_eval.py
+++ b/lib/dtu_eval.py
@@ -34,7 +34,7 @@ def write_vis_pcd(file, points, colors):
     pcd.colors = o3d.utility.Vector3dVector(colors)
     o3d.io.write_point_cloud(file, pcd)
 
-def eval(in_file, scene, eval_dir, dataset_dir='data/DTU', suffix="", max_dist = 20, use_o3d=False, runtime=False):
+def eval(in_file, scene, eval_dir, dataset_dir=os.path.join('data', 'DTU'), suffix="", max_dist = 20, use_o3d=False, runtime=False):
     # default dtu values
     scene = int(scene)
     patch = 60
@@ -109,7 +109,7 @@ def eval(in_file, scene, eval_dir, dataset_dir='data/DTU', suffix="", max_dist =
 
     pbar.update(1)
     pbar.set_description('masking data pcd')
-    obs_mask_file = loadmat(f'{dataset_dir}/ObsMask/ObsMask{scene}_10.mat')
+    obs_mask_file = loadmat(os.path.join(dataset_dir, 'ObsMask', f'ObsMask{scene}_10.mat'))
     ObsMask, BB, Res = [obs_mask_file[attr] for attr in ['ObsMask', 'BB', 'Res']]
     BB = BB.astype(np.float32)
 
@@ -127,11 +127,11 @@ def eval(in_file, scene, eval_dir, dataset_dir='data/DTU', suffix="", max_dist =
 
     if use_o3d:
         # use open3d
-        stl_pcd = o3d.io.read_point_cloud(f'{dataset_dir}/Points/stl/stl{scene:03}_total.ply')
+        stl_pcd = o3d.io.read_point_cloud(os.path.join(dataset_dir, 'Points', 'stl', f'stl{scene:03}_total.ply'))
         stl = np.asarray(stl_pcd.points)
     else:
         # use trimesh
-        stl = trimesh.load(f'{dataset_dir}/Points/stl/stl{scene:03}_total.ply')
+        stl = trimesh.load(os.path.join(dataset_dir, 'Points', 'stl', f'stl{scene:03}_total.ply'))
 
     if runtime:
         num_gt = data_in_obs.shape[0] * 2
@@ -149,7 +149,7 @@ def eval(in_file, scene, eval_dir, dataset_dir='data/DTU', suffix="", max_dist =
 
     pbar.update(1)
     pbar.set_description('compute stl2data')
-    ground_plane = loadmat(f'{dataset_dir}/ObsMask/Plane{scene}.mat')['P']
+    ground_plane = loadmat(os.path.join(dataset_dir, 'ObsMask', f'Plane{scene}.mat'))['P']
 
     stl_hom = np.concatenate([stl, np.ones_like(stl[:, :1])], -1)
     above = (ground_plane.reshape((1, 4)) * stl_hom).sum(-1) > 0

--- a/lib/grid.py
+++ b/lib/grid.py
@@ -13,14 +13,14 @@ render_utils_cuda = load(
         name='render_utils_cuda',
         sources=[
             os.path.join(parent_dir, path)
-            for path in ['cuda/render_utils.cpp', 'cuda/render_utils_kernel.cu']],
+            for path in [os.path.join('cuda', 'render_utils.cpp'), os.path.join('cuda', 'render_utils_kernel.cu')]],
         verbose=True)
 
 total_variation_cuda = load(
         name='total_variation_cuda',
         sources=[
             os.path.join(parent_dir, path)
-            for path in ['cuda/total_variation.cpp', 'cuda/total_variation_kernel.cu']],
+            for path in [os.path.join('cuda', 'total_variation.cpp'), os.path.join('cuda', 'total_variation_kernel.cu')]],
         verbose=True)
 
 

--- a/lib/load_data.py
+++ b/lib/load_data.py
@@ -130,8 +130,8 @@ def load_data(args, reso_level=2, train_all=True, wmask=True, white_bg=True):
                 images = images[...,:3]*images[...,-1:]
 
     elif args.dataset_type == 'deepvoxels':
-        args.scene = args.datadir.split('/')[-1]	
-        args.datadir = os.path.join(*args.datadir.split('/')[:-1])
+        args.scene = args.datadir.split(os.sep)[-1]
+        args.datadir = os.path.join(*args.datadir.split(os.sep)[:-1])
         images, poses, render_poses, hwf, i_split = load_dv_data(scene=args.scene, basedir=args.datadir, testskip=args.testskip)
         print('Loaded deepvoxels', images.shape, render_poses.shape, hwf, args.datadir)
         i_train, i_val, i_test = i_split

--- a/lib/load_llff.py
+++ b/lib/load_llff.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os, imageio
+import shutil
 
 
 ########## Slightly modified version of LLFF data loading code
@@ -65,7 +66,7 @@ def _minify(basedir, factors=[], resolutions=[]):
         print('Minifying', r, basedir)
 
         os.makedirs(imgdir)
-        check_output('cp {}/* {}'.format(imgdir_orig, imgdir), shell=True)
+        copytree(imgdir_orig, imgdir)
 
         ext = imgs[0].split('.')[-1]
         args = ' '.join(['mogrify', '-resize', resizearg, '-format', 'png', '*.{}'.format(ext)])
@@ -75,7 +76,7 @@ def _minify(basedir, factors=[], resolutions=[]):
         os.chdir(wd)
 
         if ext != 'png':
-            check_output('rm {}/*.{}'.format(imgdir, ext), shell=True)
+            map(os.remove, glob.glob(os.path.join(imgdir, f'*.{ext}')))
             print('Removed duplicates')
         print('Done')
 

--- a/lib/load_llff.py
+++ b/lib/load_llff.py
@@ -1,5 +1,6 @@
 import numpy as np
 import os, imageio
+import glob
 import shutil
 
 
@@ -66,7 +67,7 @@ def _minify(basedir, factors=[], resolutions=[]):
         print('Minifying', r, basedir)
 
         os.makedirs(imgdir)
-        copytree(imgdir_orig, imgdir)
+        [shutil.copy(f, os.path.join(imgdir, f.split(os.sep)[-1])) for f in glob.glob(os.path.join(imgdir_orig, '*'))]
 
         ext = imgs[0].split('.')[-1]
         args = ' '.join(['mogrify', '-resize', resizearg, '-format', 'png', '*.{}'.format(ext)])
@@ -76,7 +77,7 @@ def _minify(basedir, factors=[], resolutions=[]):
         os.chdir(wd)
 
         if ext != 'png':
-            map(os.remove, glob.glob(os.path.join(imgdir, f'*.{ext}')))
+            [os.remove(f) for f in glob.glob(os.path.join(imgdir, f'*.{ext}'))]
             print('Removed duplicates')
         print('Done')
 

--- a/lib/voxurf_fine.py
+++ b/lib/voxurf_fine.py
@@ -18,7 +18,7 @@ render_utils_cuda = load(
         name='render_utils_cuda',
         sources=[
             os.path.join(parent_dir, path)
-            for path in ['cuda/render_utils.cpp', 'cuda/render_utils_kernel.cu']],
+            for path in [os.path.join('cuda', 'render_utils.cpp'), os.path.join('cuda', 'render_utils_kernel.cu')]],
         verbose=True)
 
 '''Model'''

--- a/single_runner.bat
+++ b/single_runner.bat
@@ -1,0 +1,11 @@
+@echo off
+
+set CONFIG=%1
+set WORKDIR=%2
+set SCENE=%3
+
+echo "python run.py --config %CONFIG%\coarse.py -p %WORKDIR% --no_reload --run_dvgo_init --sdf_mode voxurf_coarse --scene %SCENE%"
+python run.py --config %CONFIG%\coarse.py -p %WORKDIR% --no_reload --run_dvgo_init --sdf_mode voxurf_coarse --scene %SCENE%
+
+echo "python run.py --config %CONFIG%\fine.py --render_test -p %WORKDIR% --no_reload --sdf_mode voxurf_fine --scene %SCENE%"
+python run.py --config %CONFIG%\fine.py --render_test -p %WORKDIR% --no_reload --sdf_mode voxurf_fine --scene %SCENE%

--- a/single_runner_womask.bat
+++ b/single_runner_womask.bat
@@ -1,0 +1,11 @@
+@echo off
+
+set CONFIG=%1
+set WORKDIR=%2
+set SCENE=%3
+
+echo "python run.py --config %CONFIG%\coarse.py -p %WORKDIR% --no_reload --no_dvgo_init --sdf_mode voxurf_womask_coarse --scene %SCENE%"
+python run.py --config %CONFIG%\coarse.py -p %WORKDIR% --no_reload --no_dvgo_init --sdf_mode voxurf_womask_coarse --scene %SCENE%
+
+echo "python run.py --config %CONFIG%\fine.py --render_test -p %WORKDIR% --no_reload --no_dvgo_init --sdf_mode voxurf_womask_fine --scene %SCENE%"
+python run.py --config %CONFIG%\fine.py --render_test -p %WORKDIR% --no_reload --no_dvgo_init  --sdf_mode voxurf_womask_fine --scene %SCENE%


### PR DESCRIPTION
To allow the code to be OS-agnostic (e.g. non-wsl Windows users can use it as well), I propose a few small changes:

1. Change all hard-coded paths with forward slashes to use `os.path.join`. 
2. Change the Unix-style `cp` and `rm` commands to use built-in python methods (`shutil` or `os`).
3. Add `.bat` scripts for Windows alongside the already existing `.sh` scripts.

Please let me know how you feel about this. I'd be willing to make some more changes if required.
If you could, it would be nice if you can run the code once (e.g on Unix) to see that everything still works as expected.